### PR TITLE
Fix Resources$NotFoundException on start

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -262,7 +262,8 @@
     <string name="song_hint">Песня (2 для песни 2 или 3004 для песни 4 CD3)</string>
     <string name="song_tag_editor">Песня</string>
     <string name="songs">Песни</string>
-    <plurals name="songs_x" tools:ignore="MissingQuantity">
+    <plurals name="songs_x">
+        <item quantity="one">песня</item>
         <item quantity="few">песни</item>
         <item quantity="many">песен</item>
     </plurals>


### PR DESCRIPTION
Russian language requires the "one" quantity even for values greater than 1.

This issue makes Music-Player crash on every start.