### PR TITLE
Fix for a Tag Editor crash with flac files

### DIFF
--- a/app/src/main/java/com/maxfour/music/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/maxfour/music/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -41,9 +41,11 @@ import org.jaudiotagger.audio.exceptions.CannotReadException;
 import org.jaudiotagger.audio.exceptions.CannotWriteException;
 import org.jaudiotagger.audio.exceptions.InvalidAudioFrameException;
 import org.jaudiotagger.audio.exceptions.ReadOnlyFileException;
+import org.jaudiotagger.audio.flac.metadatablock.MetadataBlockDataPicture;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
 import org.jaudiotagger.tag.TagException;
+import org.jaudiotagger.tag.flac.FlacTag;
 import org.jaudiotagger.tag.images.Artwork;
 import org.jaudiotagger.tag.images.ArtworkFactory;
 
@@ -317,7 +319,22 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
                                 deletedArtwork = true;
                             } else if (artwork != null) {
                                 tag.deleteArtworkField();
-                                tag.setField(artwork);
+                                if (tag instanceof FlacTag && !artwork.isLinked()) {
+                                    // Workaround for a JAudioTagger bug
+                                    MetadataBlockDataPicture field = new MetadataBlockDataPicture(
+                                            artwork.getBinaryData(),
+                                            artwork.getPictureType(),
+                                            artwork.getMimeType(),
+                                            artwork.getDescription(),
+                                            artwork.getWidth(),
+                                            artwork.getHeight(),
+                                            0,
+                                            0
+                                    );
+                                    tag.setField(field);
+                                } else {
+                                    tag.setField(artwork);
+                                }
                                 wroteArtwork = true;
                             }
                         }


### PR DESCRIPTION
Whenever the uses saves changes in the Tag Editor, AbsTagEditorActivity calls Tag.setField(Artwork). After that, if Artwork.isLinked() returns false, the FlacTag implementation of Tag causes Artwork.setImageFromData() to be called while creating the field, which throws an UnsupportedOperationException for AndroidArtwok. This change introduces a workaround by creating the field manually and using Tag.setField(TagField) whenever we have to deal with non-linked artworks and FlacTags.

If left the isLinked() check there, even though I'm not sure it's necessary as Music-Player might only create non-linked artworks.